### PR TITLE
Explicitly stated the options of correctionMethod2

### DIFF
--- a/db-RDA/ui.R
+++ b/db-RDA/ui.R
@@ -254,8 +254,8 @@ shinyUI(
 				inputId = 'correctionMethod2',
 				label = 'Should negative eigenvalues be corrected by the addition of a constant to non-diagonal dissimilarities?',
 				choices = c(
-					'Yes' = TRUE,
-					'No' = FALSE
+					'Yes' = 'lingoes',
+					'No' = 'cailliez'
 				)
 			),
 			


### PR DESCRIPTION
Hi!

I was getting the error `'arg' should be one of “lingoes”, “cailliez”` when using the demo data set or my own data. Use lingoes/cailliez instead of T/F fixed it for me. I am using vegan 2.5-6.

Thanks!
Bela